### PR TITLE
Include <rtf_common.h> for a declaration of rtf_create_butterworth

### DIFF
--- a/src/bartab.c
+++ b/src/bartab.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <rtfilter.h>
+#include <rtf_common.h>
 #include "bargraph.h"
 #include "signaltab.h"
 #include "misc.h"

--- a/src/scopetab.c
+++ b/src/scopetab.c
@@ -3,6 +3,7 @@
 #endif
 #include <string.h>
 #include <rtfilter.h>
+#include <rtf_common.h>
 #include <gtk/gtk.h>
 #include <stdlib.h>
 //#include "mcp_gui.h"


### PR DESCRIPTION
Future compilers may no longer support implicit function declarations, and compilation would fail as a result.

Related to:

- https://fedoraproject.org/wiki/Changes/PortingToModernC
- https://fedoraproject.org/wiki/Toolchain/PortingToModernC

This is a copy of: https://github.com/nbourdau/mcpanel/pull/1